### PR TITLE
new parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,27 +16,13 @@ Then add **hubot-github-create-issues** to your `external-scripts.json`:
 ["hubot-github-create-issues"]
 ```
 
-## Configuration
-
-You can use either
-
-* The package use https://github.com/tombell/hubot-github-identity to authenticate the user
-* `HUBOT_GITHUB_TOKEN` environment variable to authenticate with github
-
-`HUBOT_GITHUB_USER` is the default owner of the repositories you'll target.
-
-### Acquire a token
-
-If you don't have a token yet, run this:
-
-```
-curl -i https://api.github.com/authorizations -d '{"note":"githubot","scopes":["repo"]}' -u "yourusername"
-```
-
-Enter your Github password when prompted. When you get a response, look for the "token" value.
-
 ## Hubot Commands
 
 ```
-hubot issues create for [user/]repo #label1,#label2 Something is going wrong - Some details
+hubot issues create for [user/]repo Something is going wrong --labels bug --body issue description here
 ```
+
+## Configuration
+
+The package uses https://github.com/tombell/hubot-github-identity to authenticate the user
+* `HUBOT_GITHUB_USER` is the default owner of the repositories you'll target.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,14 @@ Then add **hubot-github-create-issues** to your `external-scripts.json`:
 ## Hubot Commands
 
 ```
-hubot issues create for [user/]repo Something is going wrong --labels bug --body issue description here
+# create issue
+hubot issues create myproject Something is going wrong
+
+# create issue with labels
+hubot issues create myproject Something is going wrong --labels bug
+
+# create issue with issue body
+hubot issues create myproject Something is going wrong --body more details here
 ```
 
 ## Configuration

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   },
   "dependencies": {
     "githubot": "^1.0.0-beta2",
-    "hubot-github-identity": "^0.10.0"
+    "hubot-github-identity": "^0.10.0",
+    "cli-argparse": "1.1.x",
+    "shell-quote": "1.6.x"
   },
   "devDependencies": {
     "hubot": "2.x",

--- a/src/github-issues-create.js
+++ b/src/github-issues-create.js
@@ -27,12 +27,12 @@ module.exports = function(robot) {
   parseIssue = function(message) {
     var args = parse(message);
     var result = parseArgs(args);
-    var args = result.options;
+    var options = result.options;
     var payload = {};
     payload.title = result.unparsed.join(' ');
-    payload.milestone = args.milestone;
-    payload.body = args.body;
-    payload.labels = (args.labels || '').split(',').map(function (s) { return s.trim(); } );
+    payload.milestone = options.milestone;
+    payload.body = options.body;
+    payload.labels = (options.labels || '').split(',').map(function (s) { return s.trim(); } );
     return payload;
   };
 

--- a/src/github-issues-create.js
+++ b/src/github-issues-create.js
@@ -7,6 +7,8 @@
 // Author:
 //  wireframe
 var githubot = require('githubot');
+var parseArgs = require('cli-argparse');
+var parse = require('shell-quote').parse;
 
 module.exports = function(robot) {
   var handleTokenError, parseBody, parseLabels, parseMilestone;
@@ -20,38 +22,23 @@ module.exports = function(robot) {
         res.reply("Sorry, you haven't told me your GitHub username.  Enter your Github API token at " + auth_url + " and then tell me who you are\n\n> " + robot.name + " I am GITHUB_USERNAME");
     }
   };
-  parseLabels = function(rawLabels) {
-    if (rawLabels) {
-      return rawLabels.slice(1, -2).split(",");
-    } else {
-      return rawLabels;
-    }
+
+  // parse message input into github issue payload
+  parseIssue = function(message) {
+    var args = parse(message);
+    var result = parseArgs(args);
+    var args = result.options;
+    var payload = {};
+    payload.title = result.unparsed.join(' ');
+    payload.milestone = args.milestone;
+    payload.body = args.body;
+    payload.labels = (args.labels || '').split(',');
+    return payload;
   };
-  parseMilestone = function(rawMilestone) {
-    if (rawMilestone) {
-      return rawMilestone.slice(3, -1);
-    } else {
-      return rawMilestone;
-    }
-  };
-  parseBody = function(rawBody) {
-    if (rawBody) {
-      return rawBody.slice(2).trim();
-    } else {
-      return rawBody;
-    }
-  };
-  robot.respond(/issues create /i, function(res) {
-    var match = res.message.text.match(/issues create (for\s)?(([-_\.0-9a-z]+\/)?[-_\.0-9a-z]+) (in\s[a-z0-9]+\s)?(#[a-z0-9, ]+#\s)?([^-]+)(\s-\s.+)?/i);
-    var repo = githubot.qualified_repo(match[2]);
-    var payload = {
-      body: ""
-    };
-    payload.milestone = parseMilestone(match[4]);
-    payload.labels = parseLabels(match[5]);
-    payload.title = match[6].trim();
-    payload.body = parseBody(match[7]);
-    console.log(payload);
+
+  robot.respond(/issues create (in\s|for\s)?(\S+)\s([\s\S]*)/i, function(res) {
+    var repo = githubot.qualified_repo(res.match[2]);
+    var payload = parseIssue(res.match[3]);
     var user = res.envelope.user.name;
     robot.identity.findToken(user, function(err, token) {
       if (err) {

--- a/src/github-issues-create.js
+++ b/src/github-issues-create.js
@@ -32,7 +32,7 @@ module.exports = function(robot) {
     payload.title = result.unparsed.join(' ');
     payload.milestone = args.milestone;
     payload.body = args.body;
-    payload.labels = (args.labels || '').split(',');
+    payload.labels = (args.labels || '').split(',').map(function (s) { return s.trim(); } );
     return payload;
   };
 

--- a/src/github-issues-create.js
+++ b/src/github-issues-create.js
@@ -52,7 +52,7 @@ module.exports = function(robot) {
         });
         var url = "/repos/" + repo + "/issues";
         github.post(url, payload, function(issue) {
-          res.reply("I've opened issue #" + issue.number + " for you\n" + issue.html_url);
+          res.reply("I've opened issue " + repo + '#' + issue.number + " for you\n" + issue.html_url);
         });
       }
     });

--- a/test/github-issues-create.js
+++ b/test/github-issues-create.js
@@ -45,7 +45,7 @@ describe('github-issues-create', function() {
     it('fires listener', function() {
       expect(room.messages).to.deep.equal([
         ['alice', message],
-        ['hubot', "@alice I've opened issue #123 for you\nhttps://fake-github-url/some/path"]
+        ['hubot', "@alice I've opened issue mycompany/myproject#123 for you\nhttps://fake-github-url/some/path"]
       ]);
     });
   });
@@ -68,7 +68,7 @@ describe('github-issues-create', function() {
     it('fires listener', function() {
       expect(room.messages).to.deep.equal([
         ['alice', message],
-        ['hubot', "@alice I've opened issue #123 for you\nhttps://fake-github-url/some/path"]
+        ['hubot', "@alice I've opened issue mycompany/myproject#123 for you\nhttps://fake-github-url/some/path"]
       ]);
     });
   });
@@ -91,7 +91,7 @@ describe('github-issues-create', function() {
     it('fires listener', function() {
       expect(room.messages).to.deep.equal([
         ['alice', message],
-        ['hubot', "@alice I've opened issue #123 for you\nhttps://fake-github-url/some/path"]
+        ['hubot', "@alice I've opened issue mycompany/myproject#123 for you\nhttps://fake-github-url/some/path"]
       ]);
     });
   });
@@ -114,7 +114,7 @@ describe('github-issues-create', function() {
     it('fires listener', function() {
       expect(room.messages).to.deep.equal([
         ['alice', message],
-        ['hubot', "@alice I've opened issue #123 for you\nhttps://fake-github-url/some/path"]
+        ['hubot', "@alice I've opened issue mycompany/myproject#123 for you\nhttps://fake-github-url/some/path"]
       ]);
     });
   });

--- a/test/github-issues-create.js
+++ b/test/github-issues-create.js
@@ -74,7 +74,7 @@ describe('github-issues-create', function() {
   });
 
   describe('when message has labels', function() {
-    var message = 'hubot issues create myproject some title --labels="foo bar,baz"';
+    var message = 'hubot issues create myproject some title --labels="foo bar, baz"';
     beforeEach(function(done) {
       nock('https://api.github.com').
         post('/repos/mycompany/myproject/issues', {

--- a/test/github-issues-create.js
+++ b/test/github-issues-create.js
@@ -32,7 +32,78 @@ describe('github-issues-create', function() {
     var message = 'hubot issues create myproject some title';
     beforeEach(function(done) {
       nock('https://api.github.com').
-        post('/repos/mycompany/myproject/issues').
+        post('/repos/mycompany/myproject/issues', {
+          title: 'some title'
+        }).
+        reply(201, {
+          number: 123,
+          html_url: 'https://fake-github-url/some/path'
+        });
+      room.user.say('alice',  message);
+      setTimeout(done, 100);
+    });
+    it('fires listener', function() {
+      expect(room.messages).to.deep.equal([
+        ['alice', message],
+        ['hubot', "@alice I've opened issue #123 for you\nhttps://fake-github-url/some/path"]
+      ]);
+    });
+  });
+
+  describe('when message has milestone', function() {
+    var message = 'hubot issues create myproject some title --milestone="v1.0"';
+    beforeEach(function(done) {
+      nock('https://api.github.com').
+        post('/repos/mycompany/myproject/issues', {
+          title: 'some title',
+          milestone: "v1.0"
+        }).
+        reply(201, {
+          number: 123,
+          html_url: 'https://fake-github-url/some/path'
+        });
+      room.user.say('alice',  message);
+      setTimeout(done, 100);
+    });
+    it('fires listener', function() {
+      expect(room.messages).to.deep.equal([
+        ['alice', message],
+        ['hubot', "@alice I've opened issue #123 for you\nhttps://fake-github-url/some/path"]
+      ]);
+    });
+  });
+
+  describe('when message has labels', function() {
+    var message = 'hubot issues create myproject some title --labels="foo bar,baz"';
+    beforeEach(function(done) {
+      nock('https://api.github.com').
+        post('/repos/mycompany/myproject/issues', {
+          title: 'some title',
+          labels: ['foo bar', 'baz']
+        }).
+        reply(201, {
+          number: 123,
+          html_url: 'https://fake-github-url/some/path'
+        });
+      room.user.say('alice',  message);
+      setTimeout(done, 100);
+    });
+    it('fires listener', function() {
+      expect(room.messages).to.deep.equal([
+        ['alice', message],
+        ['hubot', "@alice I've opened issue #123 for you\nhttps://fake-github-url/some/path"]
+      ]);
+    });
+  });
+
+  describe('when message has multiline body', function() {
+    var message = 'hubot issues create myproject some title --body="multiline\nbody"';
+    beforeEach(function(done) {
+      nock('https://api.github.com').
+        post('/repos/mycompany/myproject/issues', {
+          title: 'some title',
+          body: "multiline\nbody"
+        }).
         reply(201, {
           number: 123,
           html_url: 'https://fake-github-url/some/path'


### PR DESCRIPTION
use cli style options for issue payload

What changed?
* update regex to match body with newlines
* add `--labels` option for comma separated labels
* add `--milestone` option for setting milestone
* add `--body` option for setting issue body

Examples:
```
# create issue
hubot issues create myproject Something is going wrong

# create issue with labels
hubot issues create myproject Something is going wrong --labels bug

# create issue with issue body
hubot issues create myproject Something is going wrong --body more details here
```
