### PR TITLE
undo Slack auto-corrects that break command-line parsing

### DIFF
--- a/src/github-issues-create.js
+++ b/src/github-issues-create.js
@@ -37,6 +37,8 @@ module.exports = function(robot) {
 
   // parse message input into github issue payload
   parseIssue = function(message) {
+    // unescape Slack's "helpful" substitutions
+    message = message.replace(/—/g, '--').replace(/[“”]/g, '"');
     var args = parse(message);
     var parseOpts = {
       options: [

--- a/test/github-issues-create.js
+++ b/test/github-issues-create.js
@@ -141,4 +141,27 @@ describe('github-issues-create', function() {
       ]);
     });
   });
+
+  describe('when message has Slack auto-corrects', function() {
+    var message = 'hubot issues create myproject some title —body=“body”';
+    beforeEach(function(done) {
+      nock('https://api.github.com').
+        post('/repos/mycompany/myproject/issues', {
+          title: 'some title',
+          body: "body"
+        }).
+        reply(201, {
+          number: 123,
+          html_url: 'https://fake-github-url/some/path'
+        });
+      room.user.say('alice',  message);
+      setTimeout(done, 100);
+    });
+    it('fires listener', function() {
+      expect(room.messages).to.deep.equal([
+        ['alice', message],
+        ['hubot', "@alice I've opened issue mycompany/myproject#123 for you\nhttps://fake-github-url/some/path"]
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
Slack likes to "help" with message formatting by converting quotes to "fancy quotes" and "--" to "—". Unescape those before parsing as a shell command.